### PR TITLE
adopt to new action scheme

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,9 +1,0 @@
-workflow "Run sync_issues_to_jira tests" {
-  on = "push"
-  resolves = ["Run JIRA Sync Unit Tests"]
-}
-
-action "Run JIRA Sync Unit Tests" {
-  uses = "./sync_issues_to_jira"
-  runs = [ "/test_sync_issue.py" ]
-}

--- a/.github/workflows/test_jira_sync.yml
+++ b/.github/workflows/test_jira_sync.yml
@@ -1,0 +1,16 @@
+name: Run JIRA Sync Unit Tests
+
+on: [push]
+
+jobs:
+  test_jira_sync:
+    name: test_jira_sync
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Test JIRA sync
+        uses: ./sync_issues_to_jira
+        with:
+          entrypoint: ./sync_issues_to_jira/test_sync_to_jira.py

--- a/sync_issues_to_jira/Dockerfile
+++ b/sync_issues_to_jira/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get install -y curl && curl -sL https://deb.nodesource.com/setup_11.x | 
 RUN apt-get install -y nodejs npm && npm i markdown2confluence -g
 
 ADD sync_issue.py /sync_issue.py
-ADD test_sync_issue.py /test_sync_issue.py
+ADD sync_pr.py /sync_pr.py
+ADD sync_to_jira.py /sync_to_jira.py
 
-ENTRYPOINT ["/sync_issue.py"]
+ENTRYPOINT ["/sync_to_jira.py"]

--- a/sync_issues_to_jira/sync_pr.py
+++ b/sync_issues_to_jira/sync_pr.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+#
+# Copyright 2019 Espressif Systems (Shanghai) PTE LTD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+from jira import JIRA
+from github import Github
+from sync_issue import _find_jira_issue, _create_jira_issue
+
+
+def sync_remain_prs(jira):
+    """
+    Sync remain PRs (i.e. PRs without any comments) to Jira
+    """
+    github = Github(os.environ['GITHUB_TOKEN'])
+    repo = github.get_repo(os.environ['GITHUB_REPOSITORY'])
+    prs = repo.get_pulls(state="open", sort="created", base="master", direction="desc")
+    for pr in prs:
+        if not pr.comments:
+            # mock a github issue using current PR
+            gh_issue = {"pull_request": True,
+                        "labels": [{"name": l.name} for l in pr.labels],
+                        "number": pr.number,
+                        "title": pr.title,
+                        "html_url": pr.html_url,
+                        "user": {"login": pr.user.login},
+                        "state": pr.state,
+                        "body": pr.body}
+            issue = _find_jira_issue(jira, gh_issue)
+            if issue is None:
+                _create_jira_issue(jira, gh_issue)

--- a/sync_issues_to_jira/sync_to_jira.py
+++ b/sync_issues_to_jira/sync_to_jira.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+#
+# Copyright 2019 Espressif Systems (Shanghai) PTE LTD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from jira import JIRA
+import os
+import sys
+import json
+from sync_pr import sync_remain_prs
+from sync_issue import *
+
+
+class _JIRA(JIRA):
+    def applicationlinks(self):
+        return []  # disable this function as we don't need it and it makes add_remote_links() slow
+
+
+def main():
+    # Connect to Jira server
+    print('Connecting to Jira Server...')
+    jira = _JIRA(os.environ['JIRA_URL'],
+                 basic_auth=(os.environ['JIRA_USER'],
+                             os.environ['JIRA_PASS']))
+
+    # Check if it's a cron job
+    if os.environ.get('INPUT_CRON_JOB'):
+        sync_remain_prs(jira)
+        return
+
+    # The path of the file with the complete webhook event payload. For example, /github/workflow/event.json.
+    with open(os.environ['GITHUB_EVENT_PATH'], 'r') as f:
+        event = json.load(f)
+        json.dump(event, sys.stdout, indent=4)
+
+    event_name = os.environ['GITHUB_EVENT_NAME']  # The name of the webhook event that triggered the workflow.
+    action = event["action"]
+
+    if event_name == 'pull_request':
+        # Treat pull request events just like issues events for syncing purposes
+        # (we can check the 'pull_request' key in the "issue" later to know if this is an issue or a PR)
+        event_name = 'issues'
+        event["issue"] = event["pull_request"]
+        if "pull_request" not in event["issue"]:
+            event["issue"]["pull_request"] = True  # we don't care about the value
+
+    action_handlers = {
+        'issues': {
+            'opened': handle_issue_opened,
+            'edited': handle_issue_edited,
+            'closed': handle_issue_closed,
+            'deleted': handle_issue_deleted,
+            'reopened': handle_issue_reopened,
+            'labeled': handle_issue_labeled,
+            'unlabeled': handle_issue_unlabeled,
+        },
+        'issue_comment': {
+            'created': handle_comment_created,
+            'edited': handle_comment_edited,
+            'deleted': handle_comment_deleted,
+        },
+    }
+
+    if event_name not in action_handlers:
+        print("No handler for event '%s'. Skipping." % event_name)
+    elif action not in action_handlers[event_name]:
+        print("No handler '%s' action '%s'. Skipping." % (event_name, action))
+    else:
+        action_handlers[event_name][action](jira, event)
+
+
+if __name__ == "__main__":
+    main()

--- a/sync_issues_to_jira/test_sync_to_jira.py
+++ b/sync_issues_to_jira/test_sync_to_jira.py
@@ -17,6 +17,7 @@
 import jira
 import github
 import json
+import sync_to_jira
 import sync_issue
 import os
 import unittest
@@ -48,6 +49,7 @@ def run_sync_issue(event_name, event, jira_issue=None):
         os.environ['JIRA_URL'] = 'https://test.test:88/'
         os.environ['JIRA_USER'] = 'test_user'
         os.environ['JIRA_PASS'] = 'test_pass'
+        os.environ['GITHUB_REPOSITORY'] = 'fake/fake'
 
         github_class = create_autospec(github.Github)
 
@@ -83,9 +85,9 @@ def run_sync_issue(event_name, event, jira_issue=None):
         else:
             jira_class.return_value.search_issues.return_value = []
 
-        sync_issue._JIRA = jira_class
+        sync_to_jira._JIRA = jira_class
         sync_issue.Github = github_class
-        sync_issue.main()
+        sync_to_jira.main()
 
         return jira_class.return_value  # mock JIRA object
 


### PR DESCRIPTION
- [x] Update the workflow scheme with the new one. 

- [x] Simplify the way to get the 'org/repo' by using `GITHUB_REPOSITORY` environment variable ref: [default environment variables](https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-actions#default-environment-variables)

- [x] Add sync_remain_prs to sync the remaining PRs to Jira