### PR TITLE
Bugfix/disable sync in forks

### DIFF
--- a/sync_issues_to_jira/Dockerfile
+++ b/sync_issues_to_jira/Dockerfile
@@ -16,5 +16,6 @@ RUN apt-get install -y nodejs npm && npm i markdown2confluence -g
 ADD sync_issue.py /sync_issue.py
 ADD sync_pr.py /sync_pr.py
 ADD sync_to_jira.py /sync_to_jira.py
+ADD test_sync_to_jira.py /test_sync_to_jira.py
 
-ENTRYPOINT ["/sync_to_jira.py"]
+ENTRYPOINT ["/usr/bin/python3", "/sync_to_jira.py"]

--- a/sync_issues_to_jira/README.md
+++ b/sync_issues_to_jira/README.md
@@ -74,7 +74,7 @@ The best way to run the tests is in the docker container, as this is the same en
 ## Build image and run tests in a temporary container:
 
 ```
-docker build . --tag jira-sync && docker run --rm jira-sync --entrypoint=/test_sync_issue.py jira-sync
+docker build . --tag jira-sync && docker run --rm --entrypoint=/test_sync_to_jira.py jira-sync
 ```
 
 ## Rebuild container and run tests multiple times
@@ -91,7 +91,7 @@ docker run -td --name jira-sync --entrypoint=/bin/sh jira-sync
 For each test run, copy the Python files to the running container and run the test program:
 
 ```
-docker cp . jira-sync:/ && docker exec jira-sync /test_sync_issue.py
+docker cp . jira-sync:/ && docker exec jira-sync /test_sync_to_jira.py
 ```
 
 Once finished, kill the container:

--- a/sync_issues_to_jira/sync_to_jira.py
+++ b/sync_issues_to_jira/sync_to_jira.py
@@ -28,6 +28,10 @@ class _JIRA(JIRA):
 
 
 def main():
+    if 'GITHUB_REPOSITORY' not in os.environ:
+        print('Not running in GitHub action context, nothing to do')
+        return
+
     if not os.environ['GITHUB_REPOSITORY'].startswith('espressif/'):
         print('Not an Espressif repo, nothing to sync to JIRA')
         return

--- a/sync_issues_to_jira/sync_to_jira.py
+++ b/sync_issues_to_jira/sync_to_jira.py
@@ -28,6 +28,10 @@ class _JIRA(JIRA):
 
 
 def main():
+    if not os.environ['GITHUB_REPOSITORY'].startswith('espressif/'):
+        print('Not an Espressif repo, nothing to sync to JIRA')
+        return
+
     # Connect to Jira server
     print('Connecting to Jira Server...')
     jira = _JIRA(os.environ['JIRA_URL'],

--- a/sync_issues_to_jira/test_sync_to_jira.py
+++ b/sync_issues_to_jira/test_sync_to_jira.py
@@ -49,7 +49,7 @@ def run_sync_issue(event_name, event, jira_issue=None):
         os.environ['JIRA_URL'] = 'https://test.test:88/'
         os.environ['JIRA_USER'] = 'test_user'
         os.environ['JIRA_PASS'] = 'test_pass'
-        os.environ['GITHUB_REPOSITORY'] = 'fake/fake'
+        os.environ['GITHUB_REPOSITORY'] = 'espressif/fake'
 
         github_class = create_autospec(github.Github)
 
@@ -98,8 +98,8 @@ def run_sync_issue(event_name, event, jira_issue=None):
 class TestIssuesEvents(unittest.TestCase):
 
     def test_issue_opened(self):
-        issue = {"html_url": "https://github.com/fake/fake/issues/3",
-                 "repository_url": "https://github.com/fake/fake",
+        issue = {"html_url": "https://github.com/espressif/fake/issues/3",
+                 "repository_url": "https://github.com/espressif/fake",
                  "number": 3,
                  "title": "Test issue",
                  "body": "I am a new test issue\nabc\n测试\n",
@@ -132,7 +132,7 @@ class TestIssuesEvents(unittest.TestCase):
         # check that the github repo was updated via expected sequence of API calls
         sync_issue.Github.assert_called_with(MOCK_GITHUB_TOKEN)
         github_obj = sync_issue.Github.return_value
-        github_obj.get_repo.assert_called_with("fake/fake")
+        github_obj.get_repo.assert_called_with("espressif/fake")
         repo_obj = github_obj.get_repo.return_value
         repo_obj.get_issue.assert_called_with(issue["number"])
         issue_obj = repo_obj.get_issue.return_value
@@ -159,8 +159,8 @@ class TestIssuesEvents(unittest.TestCase):
         self.assertEqual(False, new_status["resolved"])
 
     def test_issue_edited(self):
-        issue = {"html_url": "https://github.com/fake/fake/issues/11",
-                 "repository_url": "https://github.com/fake/fake",
+        issue = {"html_url": "https://github.com/espressif/fake/issues/11",
+                 "repository_url": "https://github.com/espressif/fake",
                  "number": 11,
                  "title": "Edited issue",
                  "body": "Edited issue content goes here",
@@ -185,7 +185,7 @@ class TestIssuesEvents(unittest.TestCase):
         """
         if gh_issue is None:
             gh_number = hash(action) % 43
-            gh_issue = {"html_url": "https://github.com/fake/fake/issues/%d" % gh_number,
+            gh_issue = {"html_url": "https://github.com/espressif/fake/issues/%d" % gh_number,
                         "number": gh_number,
                         "title": "Test issue",
                         "body": "I am a test issue\nabc\n\n",
@@ -212,8 +212,8 @@ class TestIssuesEvents(unittest.TestCase):
         return m_jira
 
     def test_pr_opened(self):
-        pr = {"html_url": "https://github.com/fake/fake/pulls/4",
-              "base": {"repo": {"html_url": "https://github.com/fake/fake"}},
+        pr = {"html_url": "https://github.com/espressif/fake/pulls/4",
+              "base": {"repo": {"html_url": "https://github.com/espressif/fake"}},
               "number": 4,
               "title": "Test issue",
               "body": "I am a new Pull Request!\nabc\n测试\n",
@@ -251,8 +251,8 @@ class TestIssueCommentEvents(unittest.TestCase):
         """
         if gh_issue is None:
             gh_number = hash(action) % 50
-            gh_issue = {"html_url": "https://github.com/fake/fake/issues/%d" % gh_number,
-                        "repository_url": "https://github.com/fake/fake",
+            gh_issue = {"html_url": "https://github.com/espressif/fake/issues/%d" % gh_number,
+                        "repository_url": "https://github.com/espressif/fake",
                         "number": gh_number,
                         "title": "Test issue",
                         "body": "I am a test issue\nabc\n\n",
@@ -262,7 +262,7 @@ class TestIssueCommentEvents(unittest.TestCase):
         if gh_comment is None:
             gh_comment_id = hash(action) % 404
             gh_comment = {"html_url": gh_issue["html_url"] + "#" + str(gh_comment_id),
-                          "repository_url": "https://github.com/fake/fake",
+                          "repository_url": "https://github.com/espressif/fake",
                           "id": gh_comment_id,
                           "user": {"login": "commentuser"},
                           "body": "ZOMG a comment!"


### PR DESCRIPTION
Fixes problem where the cron job to sync PRs runs in forks of Espressif repos and produces errors each time:
https://github.com/espressif/esp-idf/pull/4374#issuecomment-558297256

Also updates & fixes unit test instructions