### PR TITLE
donot sync issues from collaborators

### DIFF
--- a/sync_issues_to_jira/sync_pr.py
+++ b/sync_issues_to_jira/sync_pr.py
@@ -28,7 +28,7 @@ def sync_remain_prs(jira):
     repo = github.get_repo(os.environ['GITHUB_REPOSITORY'])
     prs = repo.get_pulls(state="open", sort="created", direction="desc")
     for pr in prs:
-        if not pr.comments:
+        if not repo.has_in_collaborators(pr.user.login) and not pr.comments:
             # mock a github issue using current PR
             gh_issue = {"pull_request": True,
                         "labels": [{"name": l.name} for l in pr.labels],

--- a/sync_issues_to_jira/sync_to_jira.py
+++ b/sync_issues_to_jira/sync_to_jira.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 from jira import JIRA
+from github import Github
 import os
 import sys
 import json
@@ -62,6 +63,12 @@ def main():
         event["issue"] = event["pull_request"]
         if "pull_request" not in event["issue"]:
             event["issue"]["pull_request"] = True  # we don't care about the value
+
+    # don't sync if user is our collaborator
+    github = Github(os.environ['GITHUB_TOKEN'])
+    repo = github.get_repo(os.environ['GITHUB_REPOSITORY'])
+    if repo.has_in_collaborators(event["issue"]["user"]["login"]):
+        return
 
     action_handlers = {
         'issues': {


### PR DESCRIPTION
This PR is trying to avoid syncing GitHub events to Jira if the issue owner is our collaborator.