### PR TITLE
sync_to_jira: Only skip PRs opened by collaborators, not issues

### DIFF
--- a/sync_issues_to_jira/sync_to_jira.py
+++ b/sync_issues_to_jira/sync_to_jira.py
@@ -67,7 +67,10 @@ def main():
     # don't sync if user is our collaborator
     github = Github(os.environ['GITHUB_TOKEN'])
     repo = github.get_repo(os.environ['GITHUB_REPOSITORY'])
-    if repo.has_in_collaborators(event["issue"]["user"]["login"]):
+    gh_issue = event["issue"]
+    is_pr = "pull_request" in gh_issue
+    if is_pr and repo.has_in_collaborators(gh_issue["user"]["login"]):
+        print("Skipping issue sync for Pull Request from collaborator")
         return
 
     action_handlers = {


### PR DESCRIPTION
Allows collaborators to use 'Reference comment in new issue' and similar.

Includes second commit with infrastructure fixes: update the Docker image to Debian 10, fix an issue with the mocked objects in testing, pin all the package versions we use.