### PR TITLE
Windows platform label to component in Jira

### DIFF
--- a/sync_issues_to_jira/sync_issue.py
+++ b/sync_issues_to_jira/sync_issue.py
@@ -71,6 +71,10 @@ def handle_issue_labeled(jira, event):
     if _check_issue_label(new_label) is None:
         return
 
+    if new_label.lower() == "windows: platform":
+        os.environ['JIRA_COMPONENT'] = 'windows platform'
+        _update_components_field(jira, {}, jira_issue)
+    
     if new_label not in labels:
         labels.append(new_label)
         jira_issue.update(fields={"labels": labels})

--- a/sync_issues_to_jira/sync_issue.py
+++ b/sync_issues_to_jira/sync_issue.py
@@ -74,6 +74,7 @@ def handle_issue_labeled(jira, event):
     if new_label.lower() == "windows: platform":
         os.environ['JIRA_COMPONENT'] = 'windows platform'
         _update_components_field(jira, {}, jira_issue)
+        return
     
     if new_label not in labels:
         labels.append(new_label)


### PR DESCRIPTION
When new label "Platform: Windows" is added set windows platfrom comonent to Jira issue instead of label