### PR TITLE
Add github action to upload components

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,13 @@
+name: Lint code in the repo
+
+on:
+  push:
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Espressif Github Actions
 
-[Github Actions](https://developer.github.com/actions/) developed/used by Espressif to help manage GitHub repos.
+[Github Actions](https://developer.github.com/actions/) developed by Espressif to help manage GitHub repositories.
 
-* `sync_issues_to_jira` performs one way syncing of GitHub issues into a JIRA project.
-* `release_zips` creates a zip file from a tagged version to attach to a release (recursive clone, unlike the automatic GitHub source archives.)
+- [sync_issues_to_jira](sync_issues_to_jira/) performs one-way syncing of GitHub issues into a JIRA project.
+- [release_zips](release_zips/) creates a zip file from a tagged version to attach to a release (recursive clone, unlike the automatic GitHub source archives.)
+- [upload_components](upload_components/) uploads components from a GitHub repo to [Espressif Component Service](https://components.espressif.com)
 
-# Support and Changes
+## Support and Changes
 
-* Raising issues and sending Pull Requests is very welcome.
+- Raising issues and sending Pull Requests is very welcome.
+- However, please remember that some actions serve Espressif's internal GitHub integration needs. Issues or Pull Requests which aren't useful for those needs may not be addressed or merged. Sorry.
 
-* However, please remember this repository exists to serve Espressif's internal GitHub integration needs. Issues or Pull Requests which aren't useful for those needs may not be addressed or merged. Sorry.
-
-# License
+## License
 
 Apache License 2.0

--- a/upload_components/Dockerfile
+++ b/upload_components/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.9-slim-buster
+
+RUN pip install idf-component-manager
+
+COPY upload.sh /upload.sh
+
+ENTRYPOINT  ["/upload.sh"]

--- a/upload_components/README.md
+++ b/upload_components/README.md
@@ -1,0 +1,53 @@
+# GitHub Action to upload ESP-IDF components to the component service
+
+This action uploads [ESP-IDF](https://github.com/espressif/esp-idf) components from a GitHub repository to [Espressif Component Service](https://components.espressif.com).
+
+## Usage
+
+The action requires `api_token` and `namespace` parameters to be set. If the repository contains the only component stored in the root of the repository, then the `name` parameter is also required. If the repository contains more than 1 component in subdirectories, it's necessary to set the `directories` parameter to the semicolon-separated list of directories with components. In this case, the base name of the directory will be used as a component name.
+
+For successful upload, a component should be created in advance, for example using `idf.py create-remote-component` command.
+
+### Handling versions
+
+If the version in the manifest file is not on the service yet this action will upload it. Every version of the component can be uploaded to the service only once.
+
+It's recommended to change the version in the manifest only when it's ready to be published.
+An alternative supported workflow is to set parameter `skip_pre_release` to any non-empty string and use [pre-release](https://semver.org/#spec-item-9) versions (like `1.0.0-dev`) during development and then change the version to a stable (like `1.0.0`) for release.
+
+If the component with the same version is already on the service the action will ignore it silently.
+
+### Example workflow
+
+```yaml
+name: Push components to https://components.espressif.com
+on:
+  push:
+    branches:
+      - main
+jobs:
+  upload_components:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          submodules: "recursive"
+
+      - name: Upload components to the component service
+        uses: espressif/github-actions/upload_components@master
+        with:
+          directories: "components/my_component;components/another_component"
+          namespace: "espressif"
+          api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
+```
+
+## Parameters
+
+| Input            | Optional | Default   | Description                                                          |
+| ---------------- | -------- | --------- | -------------------------------------------------------------------- |
+| api_token        | ❌       |           | API Token for component service                                      |
+| namespace        | ❌       |           | Component namespace                                                  |
+| name             | ✔ / ❌   |           | Name of the component, required if only 1 directory is set           |
+| directories      | ✔        | Repo root | Semicolon separated list of directories with components              |
+| service_url      | ✔        |           | API Endpoint                                                         |
+| skip_pre_release | ✔        | False     | Flag to skip [pre-release](https://semver.org/#spec-item-9) versions |

--- a/upload_components/action.yml
+++ b/upload_components/action.yml
@@ -1,0 +1,33 @@
+name: "Upload components"
+description: "Upload components to Espressif component service"
+inputs:
+  api_token:
+    description: "API Token for component service"
+    required: true
+  namespace:
+    description: "Component namespace"
+    required: true
+  directories:
+    description: "Semicolon separated list of directories with components to upload"
+    required: false
+  name:
+    description: "Name of the component. Required, if `directories` are not set.
+      If `directories` contain more than 1 location,
+      the name of the component directory is used instead and `name` is ignored."
+    required: false
+  service_url:
+    description: "Component service API endpoint"
+    required: false
+  skip_pre_release:
+    description: "Flag to skip pre-release versions. Set it to any non-empty string to skip pre-release versions."
+    required: false
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  env:
+    COMPONENTS_DIRECTORIES: ${{ inputs.directories }}
+    COMPONENTS_NAMESPACE: ${{ inputs.namespace }}
+    COMPONENT_NAME: ${{ inputs.name }}
+    IDF_COMPONENT_API_TOKEN: ${{ inputs.api_token }}
+    DEFAULT_COMPONENT_SERVICE_URL: ${{ inputs.service_url }}
+    SKIP_PRE_RELEASE: ${{ inputs.skip_pre_release }}

--- a/upload_components/upload.sh
+++ b/upload_components/upload.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+IFS=';' read -ra DIRECTORIES <<<"${COMPONENTS_DIRECTORIES:-.}"
+NAMESPACE=${COMPONENTS_NAMESPACE:-espressif}
+if [ -n "$SKIP_PRE_RELEASE" ]; then
+    SKIP_PRE_RELEASE_FLAG="--skip-pre-release"
+fi
+
+NUMBER_OF_DIRECTORIES="${#DIRECTORIES[@]}"
+echo "Processing $NUMBER_OF_DIRECTORIES components"
+
+for ITEM in "${DIRECTORIES[@]}"; do
+    FULL_PATH="${GITHUB_WORKSPACE?}/${ITEM}"
+    if [ "$NUMBER_OF_DIRECTORIES" -eq "1" ]; then
+        NAME=${COMPONENT_NAME?}
+    else
+        NAME=$(basename "$(realpath "${FULL_PATH}")")
+    fi
+
+    echo "Processing component \"$NAME\" at $ITEM"
+    python3 -m idf_component_manager upload-component \
+        --path="${FULL_PATH}" \
+        --namespace="${NAMESPACE}" \
+        --name="${NAME}" \
+        ${SKIP_PRE_RELEASE_FLAG}
+
+    EXIT_CODE=$?
+    # Exit code 144 is returned when component is already uploaded
+    if [ "$EXIT_CODE" -ne "0" ] && [ "$EXIT_CODE" -ne "144" ]; then
+        echo "An error occurred while uploading the new version of ${NAMESPACE}/${NAME}."
+        exit 1
+    fi
+done


### PR DESCRIPTION
Add configurable GitHub action to upload components from GitHub repo to [Espressif Component Service](https://components.espressif.com)

| Input            | Optional | Default   | Description                                                          |
| ---------------- | -------- | --------- | -------------------------------------------------------------------- |
| api_token        | ❌       |           | API Token for component service                                      |
| namespace        | ❌       |           | Component namespace                                                  |
| name             | ✔ / ❌   |           | Name of the component, required if only 1 directory is set           |
| directories      | ✔        | Repo root | Semicolon separated list of directories with components              |
| service_url      | ✔        |           | API Endpoint                                                         |
| skip_pre_release | ✔        | False     | Flag to skip [pre-release](https://semver.org/#spec-item-9) versions |
