### PR TITLE
Add release_zips action

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [Github Actions](https://developer.github.com/actions/) developed/used by Espressif to help manage GitHub repos.
 
 * `sync_issues_to_jira` performs one way syncing of GitHub issues into a JIRA project.
+* `release_zips` creates a zip file from a tagged version to attach to a release (recursive clone, unlike the automatic GitHub source archives.)
 
 # Support and Changes
 

--- a/release_zips/Dockerfile
+++ b/release_zips/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.9-slim-buster
+
+RUN apt-get update && apt-get install -y p7zip-full git && pip install PyGithub
+
+ADD release_zips.py /release_zips.py
+
+ENTRYPOINT ["python", "/release_zips.py"]

--- a/release_zips/README.md
+++ b/release_zips/README.md
@@ -1,0 +1,40 @@
+# Release zips
+
+If you need to distribute source zip files containing a recursively cloned working directory of your repo (such as we do for ESP-IDF), then this action can automatically create one and attach it to a draft release whenever a matching tag is pushed.
+
+The difference between this zip file and the automatic zip file that GitHub allows you to download from any tag or release is:
+
+* This zip file is a recursive clone that includes all submodules.
+* This zip file is a valid Git working directory
+
+## Creating a Release
+
+If a Release already exists for the given tag, then the zip file is attached to it. Otherwise, a placeholder Draft release is created and the zip file is attached to that.
+
+If the tag contains `-` then a new Draft is marked as Pre-release and this is also mentioned in the title. The naming scheme for a new draft is based on ESP-IDF, and is `$RELEASE_PROJECT_NAME [Pre-release|Release] $TAG`. Both these things can be edited before publishing the new release.
+
+## Example Workflow yaml file
+
+```yml
+name: Create recursive zip file for release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release_zips:
+    name: Create release zip files
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Create a recursive clone source zip for a Release
+        uses: espressif/github-actions/release_zips@master
+        env:
+            RELEASE_PROJECT_NAME: ESP-IDF
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+* Note the `tags` filter for `push`, this limits the tag patterns for which a zip file should be created.
+* `RELEASE_PROJECT_NAME` is the name that will be used in the Draft Release title, of the form "$RELEASE_PROJECT_NAME [Pre-release|Release] $TAG"
+* `GITHUB_TOKEN` is needed to create the release, and used as a credential when cloning from GitHub (just in case). The token is not stored in the working directory, though.

--- a/release_zips/release_zips.py
+++ b/release_zips/release_zips.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+from github import Github, GithubException
+import os
+import subprocess
+
+
+def main():
+    ref = os.environ.get("GITHUB_REF", None)
+    if not ref:
+        raise SystemExit("Not an event based on a push. Workflow configuration is wrong?")
+    REF_PREFIX = "refs/tags/"
+    if not ref.startswith(REF_PREFIX):
+        raise SystemExit("Ref {} is not a tag. Workflow configuration is wrong?".format(ref))
+    tag = ref[len(REF_PREFIX):]
+
+    github_actor = os.environ["GITHUB_ACTOR"]
+    github_token = os.environ["GITHUB_TOKEN"]
+    github_repo = os.environ["GITHUB_REPOSITORY"]
+
+    print("Connecting to GitHub...")
+    github = Github(github_token)
+    repo = github.get_repo(github_repo)
+
+    if repo.private:
+        # For private repos, git needs authentication (but set so that the
+        # remote URL doesn't embed the temporary credentials in the zip file or
+        # even store the temporary credential token in the filesystem.)
+        subprocess.run(["git",  "config", "--global", "credential.https://github.com.username", github_actor], check=True)
+        helper_cmd  = "!f() { test \"$1\" = get && echo \"password=$GITHUB_TOKEN\"; }; f"  # shell command
+        subprocess.run(["git", "config", "--global", "credential.https://github.com.helper", helper_cmd], check=True)
+
+    git_url = "https://github.com/{}.git".format(github_repo)
+    repo_name = github_repo.split("/")[1]
+    directory = "{}-{}".format(repo_name, tag)
+
+    print("Doing a full recursive clone of {} ({}) into {}...".format(git_url, tag, directory))
+    # note: it may be easier to use github's "checkout" action here, with the correct args
+    subprocess.run(["git", "clone", "--recursive", "--branch", tag, git_url, directory], check=True)
+
+    zipfile = "{}.zip".format(directory)
+    print("Zipping {}...".format(zipfile))
+    subprocess.run(["/usr/bin/7z", "a", "-mx=9", "-tzip", zipfile, directory], check=True)
+
+    try:
+        release = repo.get_release(tag)
+        print("Existing release found...")
+        if any(asset.name == zipfile for asset in release.get_assets()):
+            raise SystemExit("A release for tag {} already exists and has a zip file {}. Workflow configured wrong?".format(tag, zipfile))
+    except GithubException:
+        print("Creating release...")
+        is_prerelease = "-" in tag  # tags like vX.Y-something are pre-releases
+        release_repo_name = os.environ.get('RELEASE_PROJECT_NAME', repo_name)
+        name = "{} {} {}".format(release_repo_name,
+                                 "Pre-release" if is_prerelease else "Release",
+                                 tag)
+        release = repo.create_git_release(tag, name,
+                                          "(Draft created by Action)",
+                                          draft=True, prerelease=is_prerelease)
+
+    print("Attaching zipfile...")
+    release.upload_asset(zipfile)
+
+    print("Release URL is {}".format(release.html_url)
+)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Automate creating and attaching recursive git clones of the repo to releases, such as the zip files we attach for ESP-IDF releases.

See README in the PR branch for details.

This private repo used for testing has some releases, example: https://github.com/espressif/actions-internal-test/releases/v1.0 (includes ESP-IDF in the zip file, Action took ~7 minutes to run.)