### PR TITLE
sync_issues_to_jira: Reduce duplicate JIRA issues

### DIFF
--- a/sync_issues_to_jira/sync_to_jira.py
+++ b/sync_issues_to_jira/sync_to_jira.py
@@ -51,7 +51,7 @@ def main():
     # The path of the file with the complete webhook event payload. For example, /github/workflow/event.json.
     with open(os.environ['GITHUB_EVENT_PATH'], 'r') as f:
         event = json.load(f)
-        json.dump(event, sys.stdout, indent=4)
+        print(json.dumps(event, indent=4))
 
     event_name = os.environ['GITHUB_EVENT_NAME']  # The name of the webhook event that triggered the workflow.
     action = event["action"]


### PR DESCRIPTION
If a GitHub issue is opened and edited immediately (or labelled, etc) then there is a race between two GitHub Actions. The 'opened' event will always create a new JIRA issue, but in some cases edited/labelled events may need to create one as well (if the GitHub issue existed before syncing was enabled, or if there was some error creating the original JIRA ticket.)

Due each Action running independently, it's possible for the events to be processed out of order.

To work around the race, we wait for a while before creating any JIRA ticket in response to an edit event. This timeout may not have been enough, so extended now to a random timeout in the range 2.5-5 minutes.

It's still possible that some sequences of events will still result in duplicate JIRA tickets, though.
