### PR TITLE
bugfix: sync_issue: Allow parsing of empty markdown files

### DIFF
--- a/sync_issues_to_jira/sync_issue.py
+++ b/sync_issues_to_jira/sync_issue.py
@@ -170,6 +170,8 @@ def _markdown2wiki(markdown):
     """
     Convert markdown to JIRA wiki format. Uses https://github.com/Shogobg/markdown2confluence
     """
+    if markdown is None:
+        return "\n"  # Allow empty/blank input
     with tempfile.TemporaryDirectory() as tmp_dir:
         md_path = os.path.join(tmp_dir, 'markdown.md')
         conf_path = os.path.join(tmp_dir, 'confluence.txt')


### PR DESCRIPTION
The [script fails](https://github.com/espressif/esp-idf/runs/3363129210?check_suite_focus=true#step:4:272) when no issue description is provided (trying to write a NoneType into a file).

---
Closes IDF-3740
