### PR TITLE
sync_approved_pr: Removed redundant `git clone` step

### DIFF
--- a/github_pr_to_internal_pr/README.md
+++ b/github_pr_to_internal_pr/README.md
@@ -15,5 +15,3 @@ This script automates the process of creating branches and PRs on the internal c
 - [ ] Behaviour when PR contains multiple commits ([ref](https://github.com/espressif/github-actions/pull/17#discussion_r703454250))
 
 - [ ] Handling of conflicts while using the rebase approach
-
-- [ ] Find a better approach for `sleep(time)` as remote takes time to register a branch ([ref](https://github.com/espressif/github-actions/pull/17#discussion_r703455914))


### PR DESCRIPTION
- GitHub Actions clones the repository on which the workflow is need to be run, hence there is no need to clone the repository again
- Removed `time(sleep)` ([Ref](https://github.com/espressif/github-actions/pull/17#discussion_r703455914)) used for waiting to register remote branch (issue has been fixed on GitLab)