### PR TITLE
Add `upload_components` deprecation notice to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 - [sync_issues_to_jira](sync_issues_to_jira/) performs one-way syncing of GitHub issues into a JIRA project.
 - [release_zips](release_zips/) creates a zip file from a tagged version to attach to a release (recursive clone, unlike the automatic GitHub source archives.)
-- [upload_components](upload_components/) uploads components from a GitHub repo to [Espressif Component Service](https://components.espressif.com)
+- [upload_components](upload_components/) **DEPRECATED** Use [espressif/upload-components-ci-action](https://github.com/espressif/upload-components-ci-action) instead. Uploads components from a GitHub repo to [Espressif Component Service](https://components.espressif.com)
 - [github_pr_to_internal_pr](github_pr_to_internal_pr/) performs a sync of approved pull requests to Espressif's internal IDF integration.
 
 ## Support and Changes

--- a/upload_components/README.md
+++ b/upload_components/README.md
@@ -1,4 +1,5 @@
-# GitHub Action to upload ESP-IDF components to the component registry
+# **DEPRECATED** Use [espressif/upload-components-ci-action](https://github.com/espressif/upload-components-ci-action) instead
+## GitHub Action to upload ESP-IDF components to the component registry
 
 This action uploads [ESP-IDF](https://github.com/espressif/esp-idf) components from a GitHub repository to [Espressif Component Registry](https://components.espressif.com).
 


### PR DESCRIPTION
Add deprecation notice to the readme, but keep the action in this repo.

**NB** This PR should be merged after https://github.com/espressif/upload-components-ci-action/pull/1