### PR TITLE
sync_approved_pr: Add git repo to safe dir list

### DIFF
--- a/github_pr_to_internal_pr/Dockerfile
+++ b/github_pr_to_internal_pr/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && \
     pip3 install --upgrade pip && \
     pip3 install -r /tmp/requirements.txt
 
-# Changing the ownership of the repository after checking out
 # Error: fatal: detected dubious ownership in repository at '/github/workspace'
 #      To add an exception for this directory, call:
 #          git config --global --add safe.directory /github/workspace
@@ -22,7 +21,7 @@ RUN apt-get update && \
 # - https://github.com/actions/runner/issues/2033
 # - https://github.com/actions/checkout/issues/1048
 # - https://github.com/actions/runner-images/issues/6775
-RUN chown -R $(id -u):$(id -g) $PWD
+RUN git config --system --add safe.directory /github/workspace
 
 COPY github_pr_to_internal_pr.py /
 


### PR DESCRIPTION
## Description
- Fixed the `fatal: detected dubious ownership in the repository at '/github/workspace'` issue
- Updates the non working fix merged in #35

## Related
- https://github.com/actions/runner/issues/2033
- https://github.com/actions/checkout/issues/1048
- https://github.com/actions/runner-images/issues/6775