### PR TITLE
sync_issues_to_jira: check for an existing issue when creating

### DIFF
--- a/sync_issues_to_jira/README.md
+++ b/sync_issues_to_jira/README.md
@@ -65,6 +65,10 @@ name: Sync issues to Jira
 # This workflow will be triggered when a new issue is opened
 on: issues
 
+# Limit to single concurrent run for workflows which can create Jira issues.
+# Same concurrency group is used in issue_comment.yml
+concurrency: jira_issues
+
 jobs:
   sync_issues_to_jira:
     name: Sync issues to Jira
@@ -106,6 +110,10 @@ name: Sync remaining PRs to Jira
 on:
   schedule:
     - cron: "0 * * * *"
+
+# Limit to single concurrent run for workflows which can create Jira issues.
+# Same concurrency group is used in issue_comment.yml
+concurrency: jira_issues
 
 jobs:
   sync_prs_to_jira:

--- a/sync_issues_to_jira/sync_issue.py
+++ b/sync_issues_to_jira/sync_issue.py
@@ -31,6 +31,13 @@ JIRA_NEW_FEATURE_TYPE_ID = 10101
 
 
 def handle_issue_opened(jira, event):
+    gh_issue = event["issue"]
+    issue = _find_jira_issue(jira, gh_issue, False)
+
+    if issue is not None:
+        print('Issue already exists (another event was dispatched first?)')
+        return
+
     print('Creating new JIRA issue for new GitHub issue')
     _create_jira_issue(jira, event["issue"])
 


### PR DESCRIPTION
When a user creates an issue and sets a label, Github generates two events: issue created, issue labeled.

Previously, before we started using `concurrency: jira_issues` in workflows, two workflows would be dispatched at the same time.

In this scenario, we wanted the "issue created" workflow to actually create the issue, and "issue labeled" workflow to only update it. This was achieved using the "retry and wait" logic in _find_jira_issue function. The workflow which handled "issue created" event would proceed to create an issue right away, while the workflow for "issue updated/labelled" would wait a random amount of time. Most of the time, this was sufficient to prevent duplicate issues from being created.

Once we have started using `concurrency: jira_issues`, all workflow runs related to Jira issues started getting serialized. There are now two scenarios:
1. If the "issue created" workflow gets dispatched first, everything works correctly. The "issue labeled" workflow runs second, and at this time the Jira issue already exists. No duplicate is created.
2. If the "issue labeled" workflow gets dispatched first, it doesn't find the issue and goes into wait & retry loop. Previously, when workflows were not restricted by concurrency=1 and got started in parallel, this wait & retry loop solved the issue: it gave enough time for the other workflow to run and create the issue. Now, this doesn't happen anymore. The 2nd workflow is not started until the first one finishes, so the 1st workflow's wait & retry loop times out, and it decides to create a new issue. Once that is done, the 2nd workflow finally runs and also creates a new issue.

Fix this by checking whether an issue exists in "issue created" event handler, and skip creating if the issue exists.

I think we should also remove the "wait & retry" functionality because it serves no purpose when we use a single concurrency group. However we first need to update all our repos to use this concurrency group in the workflow, and only remove the wait & retry logic later. Therefore in this PR I have only added a check inside handle_issue_opened function.