### PR TITLE
Add 'remove_source_branch' option when creating an MR from a Github PR

### DIFF
--- a/github_pr_to_internal_pr/github_pr_to_internal_pr.py
+++ b/github_pr_to_internal_pr/github_pr_to_internal_pr.py
@@ -205,7 +205,7 @@ def main():
         raise RuntimeError('Illegal program flow!')
 
     print('Creating a merge request...')
-    mr = project_gl.mergerequests.create({'source_branch': pr_head_branch, 'target_branch': pr_base_branch, 'title': pr_title_desc})
+    mr = project_gl.mergerequests.create({'source_branch': pr_head_branch, 'target_branch': pr_base_branch, 'title': pr_title_desc, 'remove_source_branch': True})
 
     print('Updating merge request description...')
     mr_desc = '## Description \n' + pr_body + '\n ##### (Add more info here)' + '\n## Related'


### PR DESCRIPTION
The `github_pr_to_internal_pr.py` script doesn't set the `remove_source_branch` option when creating the Gitlab MR. Developers often forget to set that option manually as well when reviewing the automatically created MR. Thus, when the MR is merged, we often get a lot of stale branches that still exist.