### PR TITLE
Update `danger_pr_review` action

### DIFF
--- a/danger_pr_review/README.md
+++ b/danger_pr_review/README.md
@@ -16,6 +16,86 @@ Danger JS checks from this GH action are common to all projects.
 
 You can have additional Danger checks in your individual project alongside this Danger GH action. These checks can be stored and run in the project-specific Dangerfile. In that case you also need to add another job to project workflow yaml file, that will run these additional checks.
 
+## Shared DangerJS checks descriptions
+#### Check for commit message (prCommitMessage.ts)
+Linter for commit messages. Checks if some commit messages are not generated automatically or if they are too vague/short.
+
+*`TODO`: will be updated for the conventional commits linter (module `commitlint`)*
+
+***
+#### Check for commit history (prCommitsTooManyCommits.ts)
+In case of more than 2 commits in a pull request, the user is suggested to squash his commits and simplify the commit history.
+
+***
+#### Check for PR target branch (prTargetBranch.ts)
+Checks whether the target branch of the pull request is `master` or `main`.
+
+***
+#### Info message for project contributors (prInfoContributor.ts)
+Provides an automated message to project contributors. If the contributor is known to the project, it will only post a simple "thank you for contributing" message.
+
+If the contributor is unknown (a first-time contributor), it will then also explain the review and merge process in the published message, so that people know what to expect regarding their pull request.
+
+There is a link to the `Contributions Guide` which points to the main README file of the project. **If your project uses the `Contributions Guide`, please add a link to it in the README.**
+
+***
+#### Check for PR description (prDescription.ts)
+Evaluates whether the pull request has a sufficient description (longer than 100 characters). Comments in HTML comment tags `<!--` and `-->` are ignored.
+
+**As PR description is considered all text before first `#` character** (markdown header). 
+
+For example in case of:
+```
+This PR changes documentation of CI process
+- guide for GitHub action workflow
+- guide for usage of self-hosted runners
+
+## Related
+- https://github.com/espressif/esptool/pull/900
+
+```
+
+... as description will be considered only this part:
+```
+This PR changes documentation of CI process
+- guide for GitHub action workflow
+- guide for usage of self-hosted runners
+```
+
+If you are using pull request templates (e.g. `.github/pull_request_template.md`) for your project, modify them accordingly:
+- keep the user instructions in the HTML comment tags `<!--` and `-->`
+- structure markdown headers so the actual PR description does NOT follow any `#` header (e.g. avoid adding a `# Description` header)
+
+This is a good example of a `.github/pull_request_template.md` file that DangerJS can handle correctly:
+```markdown
+<!-- HERE FILL IN A DESCRIPTION OF THE CHANGE, at least 100 characters
+Make sure other people will be able to understand what your pull request is about -->
+
+# Fix the bug(s)
+<!-- If your change fixes any bugs, list them in this section. 
+  Otherwise, delete this section, including the section header "# Fix the bug(s)" 
+
+PLEASE INCLUDE THE ISSUE URL OR # ISSUE NUMBER HERE. -->
+
+# Tested with
+<!-- In this section, describe the hardware and software combinations with which you tested the PR change - operating system(s), development board name(s), ESP8266 and/or ESP32.
+
+  IF YOU DID NOT PERFORM ANY TESTING, WRITE "NO TESTING" in this section. -->
+
+# CI and integration tests
+
+<!-- I ran automatic integration tests of esptool.py with this change and the above hardware. The results were as follows:  
+
+Details here: https://docs.espressif.com/projects/esptool/en/latest/contributing.html#automated-integration-tests
+
+  IF YOU DID NOT PERFORM ANY TESTING, WRITE "NO TESTING" in this section. 
+-->
+
+```
+***
+***
+
+
 ## Example Workflow yaml file
 ```yml
 name: DangerJS Check
@@ -24,6 +104,7 @@ on:
     types: [opened, edited, reopened, synchronize]
 
 permissions:
+  pull-requests: write
   statuses: write
 
 
@@ -54,8 +135,13 @@ If the Danger module (new check/rule) uses an external NPM module (e.g. `axios`)
 In the GitHub action, `danger` is not installed globally (nor are its dependencies) and the `npx` call is used to start the `danger` checks in CI.
 
 
-#### Test locally
-Danger rules can be tested locally (without running the GitHub action pipeline). For local testing move to `danger_pr_review/dangerjs` and install dependencies:
+**If you are about to create a new DangerJS shared check, please consider that it must be relevant for all Espressif projects. It doesn't make sense to add project-specific checks to this GitHub action. We are trying to make this GitHub action as universal as possible.**
+
+If you have created a new DangerJS check, please be sure to document it in this file in the `## Descriptions of DangerJS Shared Controls` section so that others will know what it does.
+
+
+#### Local testing when developing DangerJS checks
+Danger checks can be also tested locally (without running the GitHub action pipeline). For local testing move to `danger_pr_review/dangerjs` and install `npm` dependencies:
 ```sh
 cd danger_pr_review/dangerjs && npm install
 ```
@@ -69,7 +155,7 @@ export GITHUB_TOKEN='**************************************'
 
 Now you can call Danger by:
 ```sh
-npx danger pr <pull_request_url>   # copy url form browser
+npx danger pr <pull_request_url>   # copy url from browser
 ```
 
 The result will appear in your terminal.

--- a/danger_pr_review/dangerjs/prDescription.ts
+++ b/danger_pr_review/dangerjs/prDescription.ts
@@ -8,9 +8,14 @@ declare const warn: (message: string, results?: DangerResults) => void;
  * @dangerjs WARN
  */
 export default function (): void {
-    const prDescription: string = danger.github.pr.body;
-    console.log(`PR description: ${prDescription}`);
+    let prDescription: string = danger.github.pr.body;
     const shortPrDescriptionThreshold: number = 100; // Description is considered too short below this number of characters
+
+    // Remove HTML comments from the PR description
+    prDescription = prDescription.replace(/<!--[\s\S]*?-->/g, '');
+
+    // Split the PR description on the '#' character (markdown header) - consider as description only the text before the first header
+    prDescription = prDescription.split('#')[0].trim();
 
     if (prDescription.length < shortPrDescriptionThreshold) {
         return warn(

--- a/danger_pr_review/dangerjs/prInfoContributor.ts
+++ b/danger_pr_review/dangerjs/prInfoContributor.ts
@@ -23,7 +23,6 @@ const messageFirstContributor: string = `
 
 📘 Please check [project Contributions Guide](https://github.com/${repoOwner}/${repoName}) of the project for the contribution checklist, information regarding code and documentation style, testing and other topics.
 
-🖊️ Please also make sure you have **read and signed** the [Contributor License Agreement for ${repoOwner}/${repoName} project](https://cla-assistant.io/${repoOwner}/${repoName}).
 
 #### Pull request review and merge process you can expect
 We do welcome contributions in the form of bug reports, feature requests and pull requests via this public GitHub repository.


### PR DESCRIPTION
This PR reflects feedback gathered when attempted to apply the `danger_pr_review` GH action to an external project (esptool)

## Changes
- PR description check now ignores comments
- PR description is treated as text before the first `#` character
- removed CLA link from automated message to first-time project contributor

## Documentation update
- updated the sample workflow for this action
  - removed `workflow_dispatch`
  - reduced token permissions 
- added sample pull request template (`.github/pull_request_template.md`) for PR description check
- description of individual DangerJS checks and required updates in the target project
- updated command in guide for local testing danger while development of new checks