### PR TITLE
docs: Update sample workflow (usage DangerJS GH action)

### DIFF
--- a/danger_pr_review/README.md
+++ b/danger_pr_review/README.md
@@ -100,19 +100,22 @@ Details here: https://docs.espressif.com/projects/esptool/en/latest/contributing
 ```yml
 name: DangerJS Check
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 permissions:
   pull-requests: write
-  statuses: write
+  contents: write
 
 
 jobs:
   pull-request-style-linter:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - name: Check out PR head
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     
     - name: DangerJS pull request linter
       uses: espressif/github-actions/danger_pr_review@master


### PR DESCRIPTION
This PR fixes an issue where `github-actions-bot` is unable to submit DangerJS output as a comment to a PR when the PR is created from an external contributor's fork.

## Changes
- `on: pull_request_target` - GH actions are triggered without manual approval from repo maintainers for external contributors.
- `with: ref: ${{{ github.event.pull_request.head.sha }}` indicating the context in which the comment should be posted

## Tested
- in the repo https://github.com/espressif/test-project-bot/pull/5

## Related
- [RDT-531](https://jira.espressif.com:8443/browse/RDT-531)


**Note:** This is just change of docs guide. The changes of the workflow have to be done in projects by PRs.