### PR TITLE
fix(sync-jira-pr): Remove condition "Sync only PRs without comments"

### DIFF
--- a/sync_issues_to_jira/sync_pr.py
+++ b/sync_issues_to_jira/sync_pr.py
@@ -28,7 +28,7 @@ def sync_remain_prs(jira):
     repo = github.get_repo(os.environ['GITHUB_REPOSITORY'])
     prs = repo.get_pulls(state="open", sort="created", direction="desc")
     for pr in prs:
-        if not repo.has_in_collaborators(pr.user.login) and not pr.comments:
+        if not repo.has_in_collaborators(pr.user.login):
             # mock a github issue using current PR
             gh_issue = {"pull_request": True,
                         "labels": [{"name": l.name} for l in pr.labels],


### PR DESCRIPTION
This solves the problem of unsynchronized PRs from repositories with an active `DangerJS for GitHub` workflow (GH action).

Danger for GitHub (bot `github-actions`) almost always creates a comment in a pull request faster than the Jira sync cronjob is triggered. Then the PR is ignored by the sync action because it already contains a comment.

If anyone knows of a compelling reason why this should remain unchanged, please explain (in which case we will close this PR and try to approach it differently).

## Related
- MM thread: https://mattermost.espressif.cn:6689/espressif/pl/4seqxnecdinf8kfzx4zswkgsda
- issue spotted in: https://github.com/espressif/esptool/pull/913