### PR TITLE
change(dangerjs): Read default branch with GitHub API

### DIFF
--- a/danger_pr_review/dangerjs/dangerfile.ts
+++ b/danger_pr_review/dangerjs/dangerfile.ts
@@ -19,7 +19,7 @@ async function runDangerRules(): Promise<void> {
     // Run danger checks
     prCommitsTooManyCommits();
     prDescription();
-    prTargetBranch();
+    await prTargetBranch();
     prCommitMessage();
 
     // Add success log if no issues

--- a/danger_pr_review/dangerjs/package-lock.json
+++ b/danger_pr_review/dangerjs/package-lock.json
@@ -7,6 +7,7 @@
             "name": "dangerjs-github",
             "license": "ISC",
             "dependencies": {
+                "@octokit/rest": "^20.0.1",
                 "axios": "^1.3.3",
                 "danger": "^11.2.3",
                 "request": "^2.88.2",
@@ -99,123 +100,148 @@
             }
         },
         "node_modules/@octokit/auth-token": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
-            "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
-            "dependencies": {
-                "@octokit/types": "^6.0.3"
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/core": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
-            "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.0.tgz",
+            "integrity": "sha512-YbAtMWIrbZ9FCXbLwT9wWB8TyLjq9mxpKdgB3dUNxQcIVTf9hJ70gRPwAcqGZdY6WdJPZ0I7jLaaNDCiloGN2A==",
             "dependencies": {
-                "@octokit/auth-token": "^2.4.4",
-                "@octokit/graphql": "^4.5.8",
-                "@octokit/request": "^5.6.3",
-                "@octokit/request-error": "^2.0.5",
-                "@octokit/types": "^6.0.3",
+                "@octokit/auth-token": "^4.0.0",
+                "@octokit/graphql": "^7.0.0",
+                "@octokit/request": "^8.0.2",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^11.0.0",
                 "before-after-hook": "^2.2.0",
                 "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/endpoint": {
-            "version": "6.0.12",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
-            "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.0.tgz",
+            "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
             "dependencies": {
-                "@octokit/types": "^6.0.3",
+                "@octokit/types": "^11.0.0",
                 "is-plain-object": "^5.0.0",
                 "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/graphql": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
-            "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.1.tgz",
+            "integrity": "sha512-T5S3oZ1JOE58gom6MIcrgwZXzTaxRnxBso58xhozxHpOqSTgDS6YNeEUvZ/kRvXgPrRz/KHnZhtb7jUMRi9E6w==",
             "dependencies": {
-                "@octokit/request": "^5.6.0",
-                "@octokit/types": "^6.0.3",
+                "@octokit/request": "^8.0.1",
+                "@octokit/types": "^11.0.0",
                 "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/openapi-types": {
-            "version": "12.11.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
-            "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+            "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
         },
         "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "2.21.3",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
-            "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-8.0.0.tgz",
+            "integrity": "sha512-2xZ+baZWUg+qudVXnnvXz7qfrTmDeYPCzangBVq/1gXxii/OiS//4shJp9dnCCvj1x+JAm9ji1Egwm1BA47lPQ==",
             "dependencies": {
-                "@octokit/types": "^6.40.0"
+                "@octokit/types": "^11.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=2"
+                "@octokit/core": ">=5"
             }
         },
         "node_modules/@octokit/plugin-request-log": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.0.tgz",
+            "integrity": "sha512-2uJI1COtYCq8Z4yNSnM231TgH50bRkheQ9+aH8TnZanB6QilOnx8RMD2qsnamSOXtDj0ilxvevf5fGsBhBBzKA==",
+            "engines": {
+                "node": ">= 18"
+            },
             "peerDependencies": {
-                "@octokit/core": ">=3"
+                "@octokit/core": ">=5"
             }
         },
         "node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "5.16.2",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
-            "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-9.0.0.tgz",
+            "integrity": "sha512-KquMF/VB1IkKNiVnzJKspY5mFgGyLd7HzdJfVEGTJFzqu9BRFNWt+nwTCMuUiWc72gLQhRWYubTwOkQj+w/1PA==",
             "dependencies": {
-                "@octokit/types": "^6.39.0",
-                "deprecation": "^2.3.1"
+                "@octokit/types": "^11.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=3"
+                "@octokit/core": ">=5"
             }
         },
         "node_modules/@octokit/request": {
-            "version": "5.6.3",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
-            "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.1.tgz",
+            "integrity": "sha512-8N+tdUz4aCqQmXl8FpHYfKG9GelDFd7XGVzyN8rc6WxVlYcfpHECnuRkgquzz+WzvHTK62co5di8gSXnzASZPQ==",
             "dependencies": {
-                "@octokit/endpoint": "^6.0.1",
-                "@octokit/request-error": "^2.1.0",
-                "@octokit/types": "^6.16.1",
+                "@octokit/endpoint": "^9.0.0",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^11.1.0",
                 "is-plain-object": "^5.0.0",
-                "node-fetch": "^2.6.7",
                 "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/request-error": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-            "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.0.tgz",
+            "integrity": "sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==",
             "dependencies": {
-                "@octokit/types": "^6.0.3",
+                "@octokit/types": "^11.0.0",
                 "deprecation": "^2.0.0",
                 "once": "^1.4.0"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/rest": {
-            "version": "18.12.0",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
-            "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+            "version": "20.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.0.1.tgz",
+            "integrity": "sha512-wROV21RwHQIMNb2Dgd4+pY+dVy1Dwmp85pBrgr6YRRDYRBu9Gb+D73f4Bl2EukZSj5hInq2Tui9o7gAQpc2k2Q==",
             "dependencies": {
-                "@octokit/core": "^3.5.1",
-                "@octokit/plugin-paginate-rest": "^2.16.8",
-                "@octokit/plugin-request-log": "^1.0.4",
-                "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+                "@octokit/core": "^5.0.0",
+                "@octokit/plugin-paginate-rest": "^8.0.0",
+                "@octokit/plugin-request-log": "^4.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "^9.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/types": {
-            "version": "6.41.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
-            "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
+            "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
             "dependencies": {
-                "@octokit/openapi-types": "^12.11.0"
+                "@octokit/openapi-types": "^18.0.0"
             }
         },
         "node_modules/@sindresorhus/is": {
@@ -610,6 +636,126 @@
             },
             "engines": {
                 "node": ">=14.13.1"
+            }
+        },
+        "node_modules/danger/node_modules/@octokit/auth-token": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+            "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+            "dependencies": {
+                "@octokit/types": "^6.0.3"
+            }
+        },
+        "node_modules/danger/node_modules/@octokit/core": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+            "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+            "dependencies": {
+                "@octokit/auth-token": "^2.4.4",
+                "@octokit/graphql": "^4.5.8",
+                "@octokit/request": "^5.6.3",
+                "@octokit/request-error": "^2.0.5",
+                "@octokit/types": "^6.0.3",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/danger/node_modules/@octokit/endpoint": {
+            "version": "6.0.12",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+            "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+            "dependencies": {
+                "@octokit/types": "^6.0.3",
+                "is-plain-object": "^5.0.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/danger/node_modules/@octokit/graphql": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+            "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+            "dependencies": {
+                "@octokit/request": "^5.6.0",
+                "@octokit/types": "^6.0.3",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/danger/node_modules/@octokit/openapi-types": {
+            "version": "12.11.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+            "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
+        },
+        "node_modules/danger/node_modules/@octokit/plugin-paginate-rest": {
+            "version": "2.21.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
+            "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
+            "dependencies": {
+                "@octokit/types": "^6.40.0"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=2"
+            }
+        },
+        "node_modules/danger/node_modules/@octokit/plugin-request-log": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+            "peerDependencies": {
+                "@octokit/core": ">=3"
+            }
+        },
+        "node_modules/danger/node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "5.16.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
+            "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
+            "dependencies": {
+                "@octokit/types": "^6.39.0",
+                "deprecation": "^2.3.1"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=3"
+            }
+        },
+        "node_modules/danger/node_modules/@octokit/request": {
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+            "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+            "dependencies": {
+                "@octokit/endpoint": "^6.0.1",
+                "@octokit/request-error": "^2.1.0",
+                "@octokit/types": "^6.16.1",
+                "is-plain-object": "^5.0.0",
+                "node-fetch": "^2.6.7",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/danger/node_modules/@octokit/request-error": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+            "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+            "dependencies": {
+                "@octokit/types": "^6.0.3",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            }
+        },
+        "node_modules/danger/node_modules/@octokit/rest": {
+            "version": "18.12.0",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+            "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+            "dependencies": {
+                "@octokit/core": "^3.5.1",
+                "@octokit/plugin-paginate-rest": "^2.16.8",
+                "@octokit/plugin-request-log": "^1.0.4",
+                "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+            }
+        },
+        "node_modules/danger/node_modules/@octokit/types": {
+            "version": "6.41.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+            "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+            "dependencies": {
+                "@octokit/openapi-types": "^12.11.0"
             }
         },
         "node_modules/dashdash": {
@@ -1263,6 +1409,126 @@
             "integrity": "sha512-I/hQzJ2a/pCGR8fkSQ9l5Yx+FQ4e7X6blNHyWBm2ojeFLT3GVzGkTj7xnyWpdclrr7Nq4dmx3xrvu70m3ypzAQ==",
             "dependencies": {
                 "@octokit/rest": "^16.43.0 || ^17.11.0 || ^18.12.0"
+            }
+        },
+        "node_modules/memfs-or-file-map-to-github-branch/node_modules/@octokit/auth-token": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+            "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+            "dependencies": {
+                "@octokit/types": "^6.0.3"
+            }
+        },
+        "node_modules/memfs-or-file-map-to-github-branch/node_modules/@octokit/core": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+            "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+            "dependencies": {
+                "@octokit/auth-token": "^2.4.4",
+                "@octokit/graphql": "^4.5.8",
+                "@octokit/request": "^5.6.3",
+                "@octokit/request-error": "^2.0.5",
+                "@octokit/types": "^6.0.3",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/memfs-or-file-map-to-github-branch/node_modules/@octokit/endpoint": {
+            "version": "6.0.12",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+            "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+            "dependencies": {
+                "@octokit/types": "^6.0.3",
+                "is-plain-object": "^5.0.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/memfs-or-file-map-to-github-branch/node_modules/@octokit/graphql": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+            "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+            "dependencies": {
+                "@octokit/request": "^5.6.0",
+                "@octokit/types": "^6.0.3",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/memfs-or-file-map-to-github-branch/node_modules/@octokit/openapi-types": {
+            "version": "12.11.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+            "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
+        },
+        "node_modules/memfs-or-file-map-to-github-branch/node_modules/@octokit/plugin-paginate-rest": {
+            "version": "2.21.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
+            "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
+            "dependencies": {
+                "@octokit/types": "^6.40.0"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=2"
+            }
+        },
+        "node_modules/memfs-or-file-map-to-github-branch/node_modules/@octokit/plugin-request-log": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+            "peerDependencies": {
+                "@octokit/core": ">=3"
+            }
+        },
+        "node_modules/memfs-or-file-map-to-github-branch/node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "5.16.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
+            "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
+            "dependencies": {
+                "@octokit/types": "^6.39.0",
+                "deprecation": "^2.3.1"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=3"
+            }
+        },
+        "node_modules/memfs-or-file-map-to-github-branch/node_modules/@octokit/request": {
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+            "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+            "dependencies": {
+                "@octokit/endpoint": "^6.0.1",
+                "@octokit/request-error": "^2.1.0",
+                "@octokit/types": "^6.16.1",
+                "is-plain-object": "^5.0.0",
+                "node-fetch": "^2.6.7",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/memfs-or-file-map-to-github-branch/node_modules/@octokit/request-error": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+            "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+            "dependencies": {
+                "@octokit/types": "^6.0.3",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            }
+        },
+        "node_modules/memfs-or-file-map-to-github-branch/node_modules/@octokit/rest": {
+            "version": "18.12.0",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+            "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+            "dependencies": {
+                "@octokit/core": "^3.5.1",
+                "@octokit/plugin-paginate-rest": "^2.16.8",
+                "@octokit/plugin-request-log": "^1.0.4",
+                "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+            }
+        },
+        "node_modules/memfs-or-file-map-to-github-branch/node_modules/@octokit/types": {
+            "version": "6.41.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+            "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+            "dependencies": {
+                "@octokit/openapi-types": "^12.11.0"
             }
         },
         "node_modules/micromatch": {

--- a/danger_pr_review/dangerjs/package.json
+++ b/danger_pr_review/dangerjs/package.json
@@ -6,6 +6,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
+        "@octokit/rest": "^20.0.1",
         "axios": "^1.3.3",
         "danger": "^11.2.3",
         "request": "^2.88.2",


### PR DESCRIPTION
DangerJS check for `TARGET BRANCH` has currently hardcoded the default project branch name `master`/`main`.
If a contributor tries to target their PR to a branch with a different name, the Danger check fails.

In some projects, the default branch may be something different than `master`/`main`.

This change always retrieves the project's default branch from the GitHub API and compares it to the target PR branch.

## Related
- issue spotted in: https://github.com/espressif/idf-examples-launchpad-ci-action/pull/1#issuecomment-1696783378