### PR TITLE
change(jira-auth): change JIRA auth method to use PAT

### DIFF
--- a/sync_issues_to_jira/README.md
+++ b/sync_issues_to_jira/README.md
@@ -183,11 +183,15 @@ The environment variables should be set in the GitHub Workflow:
 - `JIRA_ISSUE_TYPE` (optional) the JIRA issue type for new issues. If unset, "Task" is used.
 - `JIRA_COMPONENT` (optional) the name of a JIRA component to add to every issue which is synced from GitHub. The component must already exist in the JIRA project.
 
-The following secrets should be set in the workflow:
+The following secrets are needed for the workflow:
 
 - `JIRA_URL` is the main JIRA URL (doesn't have to be secret).
 - `JIRA_USER` is the JIRA username to log in with (JIRA basic auth)
-- `JIRA_PASS` is the JIRA password to log in with (JIRA basic auth)
+- `JIRA_PASS` is JIRA token (JIRA token auth) or JIRA password (JIRA basic auth) to log in with
+
+If `JIRA_PASS` is a token, it must be entered in the secret with the prefix `token:` (e.g.: `token:Xyz123**************ABC`). The `token:` prefix is used to distinguish between a password and a token type of `JIRA_PASS`. This prefix will be stripped by the script before the API call.
+
+***IMPORTANT:** These secrets are inherited from the GitHub organizational secrets (as they are common to all Espressif GitHub projects) and should not be set at the repository level. (If set at the repository level, repo secrets take precedence over org secrets.)*
 
 # Tests
 

--- a/sync_issues_to_jira/sync_to_jira.py
+++ b/sync_issues_to_jira/sync_to_jira.py
@@ -39,7 +39,16 @@ def main():
 
     # Connect to Jira server
     print('Connecting to Jira Server...')
-    jira = _JIRA(os.environ['JIRA_URL'], basic_auth=(os.environ['JIRA_USER'], os.environ['JIRA_PASS']))
+
+    # Check if the JIRA_PASS is token or password
+    token_or_pass = os.environ['JIRA_PASS']
+    if token_or_pass.startswith('token:'):
+        print("Authenticating with JIRA_TOKEN ...")
+        token = token_or_pass[6:]  # Strip the 'token:' prefix
+        jira = _JIRA(os.environ['JIRA_URL'], token_auth=token)
+    else:
+        print("Authenticating with JIRA_USER and JIRA_PASS ...")
+        jira = _JIRA(os.environ['JIRA_URL'], basic_auth=(os.environ['JIRA_USER'], token_or_pass))
 
     # Check if it's a cron job
     if os.environ.get('INPUT_CRON_JOB'):


### PR DESCRIPTION
This PR adds support for reading a token from the `JIRA_PASS` variable. This is here due to handle migration process from using username+password to PAT.

- If the `JIRA_PASS` variable starts with the `token:` prefix, token-based authentication will be used (strip `token:` part first).
- If the `JIRA_PASS` variable does not start with a `token:` prefix, basic authentication (username + password) will be used

The example workflows in the README documents retained the current version containing `JIRA_USER`. I recommend to keep it also in the template for new projects. It will be ignored anyway, but since there are already so many projects with it, maybe we can keep it as legacy code.

## Next steps
1) After merging this PR, set on org level:
- `JIRA_USER` (will be ignored during token authentication, but must be present because we don't want to change a ton of existing yaml workflows)
- `JIRA_URL`
- `JIRA_PASS` with token value in the format `token:<token-value>`

2) update Create project tools (remove uploading Jira Secrets to the GH repo)
3) remove `JIRA_USER`, `JIRA_PASS` and `JIRA_URL` from all GH repos by script

**Final state:** 
- all GitHub projects will no longer have `JIRA_USER`, `JIRA_PASS` and `JIRA_URL` secrets, everything will be managed at the org-secrets level

## Related
- https://jira.espressif.com:8443/browse/RDT-567