### PR TITLE
change(danger-github): add deprecated warning message to action output

### DIFF
--- a/danger_pr_review/README.md
+++ b/danger_pr_review/README.md
@@ -1,3 +1,7 @@
+:warning: **Deprecation Notice**: This GitHub action is scheduled for removal in March 2024. We recommend migrating to the latest version available in the [shared-github-danger](https://github.com/espressif/shared-github-dangerjs) project.
+
+---
+
 # DangerJS pull request automatic review tool - GitHub
 
 This is the DangerJS pull request linter GitHub action, that can be called from another repositories. It's purpose is to keep the style of each PR in the specified style and automatically check for simple things like correct PR description, meaningful git messages, correct PR target branch, etc.

--- a/danger_pr_review/dangerjs/dangerfile.ts
+++ b/danger_pr_review/dangerjs/dangerfile.ts
@@ -45,4 +45,6 @@ function addRetryLink(): void {
     const retryLink: string = `<sub>:repeat: You can re-run automatic PR checks by retrying the <a href="${retryLinkUrl}">DangerJS action</a></sub>`;
 
     markdown(retryLink);
+
+    markdown(`***\n:warning: **Deprecation Notice**: This GitHub action is scheduled for removal in March 2024. We recommend migrating to the latest version available in the [shared-github-danger](https://github.com/espressif/shared-github-dangerjs) project.`)
 }


### PR DESCRIPTION
This is adding deprecation warning to projects using old version of GitHub Danger linter.
- warning in docs
- warning in each output message so that project administrators can notice it

<img src="https://github.com/espressif/github-actions/assets/33937168/e85e49da-0fa0-441e-b73d-045509ae52c0" width=500px> 

## Related
- *merge after:* https://github.com/espressif/shared-github-dangerjs/pull/1