### PR TITLE
 fix(github_pr): "Closes" line formatting

### DIFF
--- a/github_pr_to_internal_pr/github_pr_to_internal_pr.py
+++ b/github_pr_to_internal_pr/github_pr_to_internal_pr.py
@@ -134,7 +134,7 @@ def sync_pr(pr_num, pr_head_branch, pr_commit_id, project_gl, pr_base_branch, pr
         git.rebase(pr_base_branch)
 
         commit = repo.head.commit
-        new_cmt_msg = f'{commit.message}\nMerges{pr_html_url}'
+        new_cmt_msg = f'{commit.message}\n\nCloses {pr_html_url}'
 
         print('Amending commit message (Adding additional info about commit)...')
         git.execute(['git','commit', '--amend', '-m', new_cmt_msg])


### PR DESCRIPTION
When syncing a Github PR to a Gitlab PR via the `PR-Sync-Rebase`, the sync script will automatically append a `Merges` line to the commit message. This extra line is misformatted, for example:

```
Some PR commit message

This commit updates ...
Mergeshttps://github.com/espressif/esp-idf/pull/XXXX
```

The `Closes` keyword [should be used instead](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link commit messages to PRs/Issues. For example...


```
Some PR commit message

This commit updates ...

Closes https://github.com/espressif/esp-idf/pull/XXXX
```
