### PR TITLE
change(jira-sync-actions): add deprecation info and warning message

### DIFF
--- a/sync_issues_to_jira/README.md
+++ b/sync_issues_to_jira/README.md
@@ -1,3 +1,7 @@
+:warning: **Deprecation Notice**: This GitHub action is deprecated and development will not continue here. We recommend migrating to the latest version available in the [espressif/sync-jira-actions](https://github.com/espressif/sync-jira-actions) project.
+
+---
+
 # GitHub to JIRA Issue Sync
 
 This is a GitHub action that performs simple one way syncing of GitHub issues into JIRA.

--- a/sync_issues_to_jira/action.yml
+++ b/sync_issues_to_jira/action.yml
@@ -1,5 +1,5 @@
-name: "GitHub to JIRA Issue Sync"
-description: "Performs simple one way syncing of GitHub issues into JIRA."
+name: "GitHub to JIRA Issue Sync [Deprecated]"
+description: "DEPRECATED: Performs simple one-way syncing of GitHub issues into JIRA. Please migrate to the new action at https://github.com/espressif/sync-jira-actions."
 branding:
   icon: "fast-forward"
   color: "green"

--- a/sync_issues_to_jira/sync_to_jira.py
+++ b/sync_issues_to_jira/sync_to_jira.py
@@ -14,6 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import warnings
+warnings.simplefilter('default', DeprecationWarning)
+warnings.warn(
+    "You are using a deprecated version of the Jira sync GitHub action. "
+    "We recommend migrating to the latest version available at https://github.com/espressif/sync-jira-actions.",
+    DeprecationWarning
+)
+
 from jira import JIRA
 from github import Github
 import os
@@ -21,6 +29,7 @@ import sys
 import json
 from sync_pr import sync_remain_prs
 from sync_issue import *
+
 
 
 class _JIRA(JIRA):


### PR DESCRIPTION
This is to add deprecation information and warnings for JIRA sync actions with GitHub.

JIRA sync GitHub actions has been migrated to independent repo: https://github.com/espressif/sync-jira-actions

## Tested
- https://github.com/espressif/test-project-bot/actions/runs/7898629371/job/21556407300#step:4:12

## Related
- https://github.com/espressif/sync-jira-actions/pull/1