### PR TITLE
change(github-pr-to-internal-pr): add deprecation info and warning message

### DIFF
--- a/github_pr_to_internal_pr/README.md
+++ b/github_pr_to_internal_pr/README.md
@@ -1,3 +1,6 @@
+:warning: **Deprecation Notice**: This GitHub action is deprecated and development will not continue here. We recommend migrating to the latest version available in the [espressif/sync-pr-to-gitlab](https://github.com/espressif/sync-pr-to-gitlab) project.
+
+---
 # Sync approved PRs to internal codebase
 
 This script automates the process of creating branches and PRs on the internal codebase of Espressif based on approved PRs on Github.

--- a/github_pr_to_internal_pr/action.yml
+++ b/github_pr_to_internal_pr/action.yml
@@ -1,5 +1,5 @@
 name: "Sync approved PRs to internal codebase"
-description: "Sync approved Github PRs to the Espressif's internal IDF integration"
+description: "DEPRECATED: Sync approved Github PRs to the Espressif's internal IDF integration"
 branding:
   icon: "fast-forward"
   color: "green"

--- a/github_pr_to_internal_pr/github_pr_to_internal_pr.py
+++ b/github_pr_to_internal_pr/github_pr_to_internal_pr.py
@@ -3,6 +3,14 @@
 # SPDX-FileCopyrightText: 2021 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+warnings.simplefilter('default', DeprecationWarning)
+warnings.warn(
+    "You are using a deprecated version of sync GitHub action. "
+    "We recommend migrating to the latest version available at https://github.com/espressif/sync-pr-to-gitlab.",
+    DeprecationWarning
+)
+
 import json
 import os
 import re


### PR DESCRIPTION
This is to add deprecation information and warnings for **Sync approved PRs to internal codebase**.

Sync approved PRs to internal codebase has been migrated to independent repo: https://github.com/espressif/sync-pr-to-gitlab

## Related
- https://github.com/espressif/sync-pr-to-gitlab/pull/1