### PR TITLE
Deprecate/update submodule versions + entire repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,35 @@
+:warning: **Deprecation Notice**: This repository has been split into individual repositories—each GitHub action in its own repository—to achieve a cleaner development process, code ownership, and proper versioning.
+
+GitHub actions from this repo will probably still work for some time, but development continues in the new locations. **This repo is now archived and read-only.**  :warning: 
+
+---
+
+:exclamation: **We strongly suggest updating your GitHub workflows to use the new repository locations.** By doing this, you can ensure you are using the proper versions of these actions with all the latest fixes and improvements.
+
+| GitHub action               | migrated to new location                                      |
+| --------------------------- | ------------------------------------------------------------- |
+| `danger_pr_review`          | https://github.com/espressif/shared-github-dangerjs           |
+| `github_pr_to_internal_pr`  | https://github.com/espressif/sync-pr-to-gitlab                |
+| `release_zips`              | -                                                             |
+| `sync_issues_to_jira`       | https://github.com/espressif/sync-jira-actions                |
+| `update_submodule_versions` | https://github.com/espressif/update-submodule-versions-action |
+| `upload_components`         | https://github.com/espressif/upload-components-ci-action      |
+
+---
+
 # Espressif Github Actions
 
 [Github Actions](https://developer.github.com/actions/) developed by Espressif to help manage GitHub repositories.
 
 - [sync_issues_to_jira](sync_issues_to_jira/) performs one-way syncing of GitHub issues into a JIRA project.
 - [release_zips](release_zips/) creates a zip file from a tagged version to attach to a release (recursive clone, unlike the automatic GitHub source archives.)
-- [upload_components](upload_components/) **DEPRECATED** Use [espressif/upload-components-ci-action](https://github.com/espressif/upload-components-ci-action) instead. Uploads components from a GitHub repo to [Espressif Component Service](https://components.espressif.com)
+- [upload_components](upload_components/) Uploads components from a GitHub repo to [Espressif Component Service](https://components.espressif.com)
 - [github_pr_to_internal_pr](github_pr_to_internal_pr/) performs a sync of approved pull requests to Espressif's internal IDF integration.
 - [danger_pr_review](danger_pr_review/) performs automatic style checking of pull requests using the DangerJS framework.
 
 ## Support and Changes
 
-- Raising issues and sending Pull Requests is very welcome.
+- Raising issues and sending Pull Requests is very welcome **in new GitHub action locations** (see the table above).
 - However, please remember that some actions serve Espressif's internal GitHub integration needs. Issues or Pull Requests which aren't useful for those needs may not be addressed or merged. Sorry.
 
 ## License

--- a/update_submodule_versions/README.md
+++ b/update_submodule_versions/README.md
@@ -1,3 +1,6 @@
+:warning: **Deprecation Notice**: This GitHub action is deprecated and development will not continue here. We recommend migrating to the latest version available in the [espressif/update-submodule-versions-action](https://github.com/espressif/update-submodule-versions-action) project.
+
+---
 # Update repository submodules action
 
 This action helps automate updates to submodules of a repository. It is similar to Dependabot's submodule update functionality, with a few extra features:

--- a/update_submodule_versions/action.yml
+++ b/update_submodule_versions/action.yml
@@ -1,5 +1,5 @@
 name: "Update submodules"
-description: "Make PRs to update submodules to new release tags"
+description: "DEPRECATED:Make PRs to update submodules to new release tags. Please migrate to the new action at https://github.com/espressif/update-submodule-versions-action"
 inputs:
   repo-token:
     description: "Github API token (for opening PRs)"


### PR DESCRIPTION
This PR adds deprecation warnings to the `update_submodule_versions` action, which is currently not used anywhere. It has been moved to a private repository and will be reviewed and possibly reworked (internal JIRA ticket RDT-792).

A deprecation notice for the entire repository has been added, along with a table of migrated GitHub actions (new locations).

---

**After merging this, the repository will be archived (stays read-only).**
